### PR TITLE
fixed extra space

### DIFF
--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -50,7 +50,7 @@ export default function ProjectCard(props) {
             image={props.imgURL}
             title="Project Image"
           />
-          <CardContent>
+          <CardContent style={{ paddingBottom: "100%" }}>
             <Typography gutterBottom variant="h5" component="h2">
               {props.data.title}
             </Typography>


### PR DESCRIPTION
## Fixed extra space glitch at the bottom of Project Cards

<img width="385" alt="Screen Shot 2021-08-17 at 10 55 01 PM" src="https://user-images.githubusercontent.com/58789967/129829446-a3130b04-148b-4a5f-893e-5ab9eeed91e3.png">
<img width="385" alt="Screen Shot 2021-08-17 at 10 55 20 PM" src="https://user-images.githubusercontent.com/58789967/129829477-ecc7bf6a-db14-4562-affe-d5c8eaaa0713.png">
